### PR TITLE
adding "height: auto" to ".entry .content img" rule

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -224,10 +224,11 @@ body.logged-out {
 .entry .content img {
   display: block;
   max-width: 100%;
+  height: auto;
 }
 
 .entry .meta {
-  text-decoration: none;  
+  text-decoration: none;
   color: #999;
   font-size: 12px;
 }


### PR DESCRIPTION
This prevents images from getting distorted, due to the `max-width: 100%` rule, when the image's markup includes width and height attributes. So, `height: auto;` will respect the img's aspect ratio and resize it properly.