### PR TITLE
Expand the click areas in the channel list

### DIFF
--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -63,12 +63,12 @@ body {
 }
 #side-menu li {
   transition: all 0.2s ease-in-out;
-  display: block;
-  padding: 1em 1em;
   border-bottom: 1px #444 solid;
 }
 #side-menu li a {
   color: white;
+  display: block;
+  padding: 1em 1em;
   text-decoration: none;
 }
 #side-menu li:hover {

--- a/views/components/channel-list.php
+++ b/views/components/channel-list.php
@@ -1,8 +1,10 @@
     <?php foreach($_SESSION['channels'] as $channel): ?>
       <li data-channel-uid="<?= e($channel['uid']) ?>">
-        <a href="/channel/<?= e(urlencode($channel['uid'])) ?>"><?= e($channel['name']) ?></a>
-        <?php if(isset($channel['unread'])): ?>
-          <span class="tag is-info <?= is_bool($channel['unread']) ? 'is-dot' : 'is-rounded' ?> <?= isset($channel['unread']) && $channel['unread'] > 0 ? '' : 'is-hidden' ?>"><?= is_bool($channel['unread']) ? '' : $channel['unread'] ?></span>
-        <?php endif ?>
+        <a href="/channel/<?= e(urlencode($channel['uid'])) ?>">
+          <?= e($channel['name']) ?>
+          <?php if(isset($channel['unread'])): ?>
+            <span class="tag is-info <?= is_bool($channel['unread']) ? 'is-dot' : 'is-rounded' ?> <?= isset($channel['unread']) && $channel['unread'] > 0 ? '' : 'is-hidden' ?>"><?= is_bool($channel['unread']) ? '' : $channel['unread'] ?></span>
+          <?php endif ?>
+        </a>
       </li>
     <?php endforeach; ?>


### PR DESCRIPTION
I keep finding myself clicking outside the names in the channel list when trying to change channels, and being surprised when nothing happens (despite the hover effect on each entry). This PR changes the click area in the channel list so that the entire area for a channel can be clicked rather than just the name. In order to make this work I've moved the `tag` span inside the link. The changes in the PR result in no visual changes, everything looks exactly as it did before.

@aaronpk Feel free to ignore this if you'd prefer. I won't be insulted :D