### PR TITLE
Expand the click areas in the main channel list

### DIFF
--- a/views/main.php
+++ b/views/main.php
@@ -16,6 +16,9 @@
 .channels a {
   text-decoration: none;
 }
+.channel-list a {
+  display: block;
+}
 </style>
 
 <div class="column">


### PR DESCRIPTION
A follow-up to [my previous PR](https://github.com/aaronpk/Monocle/pull/25), this time making the entire entry clickable in the main page channels list. This PR changes the click area in the channel list so that the entire area for a channel can be clicked rather than just the name. The changes in the PR result in no visual changes, everything looks exactly as it did before.