### PR TITLE
Mark all as read

### DIFF
--- a/app/Controller.php
+++ b/app/Controller.php
@@ -141,6 +141,23 @@ class Controller {
     ]));
     return $response->withHeader('Content-type', 'application/json');
   }
+  public function mark_all_as_read(ServerRequestInterface $request, ResponseInterface $response) {
+    $this->requireLogin();
+    $body = $request->getParsedBody();
+
+    microsub_post($_SESSION['microsub'], $_SESSION['token']['access_token'], 'timeline', [
+      'channel' => $body['channel'],
+      'method' => 'mark_read',
+      'last_read_entry' => $body['entry'],
+    ]);
+
+    $r = $this->_reloadChannels();
+
+    $response->getBody()->write(json_encode([
+      'channels' => $_SESSION['channels']
+    ]));
+    return $response->withHeader('Content-type', 'application/json');
+  }
 
   public function mark_as_unread(ServerRequestInterface $request, ResponseInterface $response) {
     $this->requireLogin();

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -97,11 +97,14 @@ body {
   position: fixed;
   width: 100vw;
   padding: .75rem;
+  display: flex;
+  justify-content: space-between;
 }
 
 #main-top h2.title {
   position: relative;
   padding-left: 45px;
+  margin-bottom: 0;
 }
 #main-top h2.title .back {
   font-size: 12pt;
@@ -219,9 +222,9 @@ label[for="nav-trigger"]:hover {
   opacity: 0.6;
 }
 
-.nav-trigger:checked + label {
-  /* left: 255px; */
-}
+/*.nav-trigger:checked + label {
+   left: 255px; 
+}*/
 
 .nav-trigger:checked ~ main {
   left: 240px;
@@ -238,4 +241,16 @@ main, label[for="nav-trigger"], #side-menu {
 
 .xray-emoji, .xray-custom-emoji {
     height: 1em;
+}
+
+.title-combo .button {
+  height: auto;
+  border: none;
+  font-size: 2rem;
+  padding: 0;
+  line-height: 1;
+}
+.title-combo .button .icon:first-child:last-child {
+  margin-left: 0.5rem;
+  font-size: 1.3rem;
 }

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -254,3 +254,6 @@ main, label[for="nav-trigger"], #side-menu {
   margin-left: 0.5rem;
   font-size: 1.3rem;
 }
+#main-top>div.dropdown {
+  margin-right: 1rem;
+}

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -98,7 +98,9 @@ body {
   width: 100vw;
   padding: .75rem;
   display: flex;
+  display: -webkit-flex;
   justify-content: space-between;
+  -webkit-justify-content: space-between;
 }
 
 #main-top h2.title {

--- a/public/index.php
+++ b/public/index.php
@@ -28,6 +28,7 @@ $route->map('GET', '/channel/{uid}', 'App\\Controller::timeline');
 $route->map('GET', '/channel/{uid}/{source}', 'App\\Controller::timeline');
 $route->map('POST', '/channels/reload', 'App\\Controller::reload_channels');
 $route->map('POST', '/microsub/mark_read', 'App\\Controller::mark_as_read');
+$route->map('POST', '/microsub/mark_all_as_read', 'App\\Controller::mark_all_as_read');
 $route->map('POST', '/microsub/mark_unread', 'App\\Controller::mark_as_unread');
 $route->map('POST', '/microsub/remove', 'App\\Controller::remove_entry');
 

--- a/views/timeline.php
+++ b/views/timeline.php
@@ -19,14 +19,14 @@
 
     <div class="dropdown is-right is-hidden-mobile">
       <div class="dropdown-trigger">
-        <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
+        <a href="#" class="button" aria-haspopup="true" aria-controls="dropdown-menu">
         <span class="icon is-small">
           <i class="fas fa-check" aria-hidden="true"></i>
         </span>
         <span class="icon is-small">
           <i class="fas fa-angle-down" aria-hidden="true"></i>
         </span>
-        </button>
+        </a>
       </div>
       <div class="dropdown-menu" id="dropdown-menu" role="menu">
         <div class="dropdown-content">

--- a/views/timeline.php
+++ b/views/timeline.php
@@ -367,9 +367,6 @@ $(function(){
     });
     
   });
-  $("#mark-all-read-modal a.close").click(function(){
-    $("#mark-all-read-modal").removeClass("is-active");
-  });
 
   $(".content.html").each(function(i,content){
     if($(content).height() >= 384) {
@@ -546,29 +543,6 @@ function mark_read(entry_ids) {
   $.post("/microsub/mark_read", {
     channel: $("#channel-uid").val(),
     entry: entry_ids
-  }, function(response){
-    update_channel_list(response.channels);
-  });
-}
-
-function mark_all_as_read() {
-  var marked = {};
-  var entry_ids = [];
-  document.querySelectorAll(".entry").forEach(function(entry){
-    var entryNum = $(entry).data("entry");
-    if(marked[entryNum] == null && $(entry).data("is-read") == 0) {
-      marked[entryNum] = true;
-      entry_ids.push($(entry).data("entry-id"));
-    }
-  });
-  entry_ids.forEach(function(eid){
-    $(".entry[data-entry-id="+eid+"]").data("is-read", 1);
-    $(".entry[data-entry-id="+eid+"]").removeClass("unread").addClass("read");
-  });
-
-  $.post("/microsub/mark_all_as_read", {
-    channel: $("#channel-uid").val(),
-    entry: $("#last-id").val()
   }, function(response){
     update_channel_list(response.channels);
   });

--- a/views/timeline.php
+++ b/views/timeline.php
@@ -338,10 +338,6 @@ $(function(){
     });
   });
 
-  // $(".mark-all-read-button a").click(function(){
-  //   $("#mark-all-read-modal").addClass("is-active");
-  // });
-
   $("a.mark-all-read-button").click(function(e){
     e.preventDefault();
     var marked = {};

--- a/views/timeline.php
+++ b/views/timeline.php
@@ -8,12 +8,56 @@
 
   <div id="main-top">
     <label for="nav-trigger" id="nav-trigger-label"></label>
-    <h2 class="title">
+    <h2 class="title is-hidden-mobile">
       <? if($source): ?>
         <a href="/channel/<?= e($channel['uid']) ?>"><?= e($channel['name']) ?></a>
       <? else: ?>
         <?= e($channel['name']) ?>
       <? endif ?>
+      
+    </h2>
+
+    <div class="dropdown is-right is-hidden-mobile">
+      <div class="dropdown-trigger">
+        <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
+        <span class="icon is-small">
+          <i class="fas fa-check" aria-hidden="true"></i>
+        </span>
+        <span class="icon is-small">
+          <i class="fas fa-angle-down" aria-hidden="true"></i>
+        </span>
+        </button>
+      </div>
+      <div class="dropdown-menu" id="dropdown-menu" role="menu">
+        <div class="dropdown-content">
+          <a href="#" class="dropdown-item mark-all-read-button">
+            Mark All Read
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <!-- Combo Menu/Title for mobile -->
+    <h2 class="title title-combo is-hidden-tablet">
+      <div class="dropdown">
+        <div class="dropdown-trigger">
+          <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
+            <?= e($channel['name']) ?>
+            <span class="icon is-small">
+              <i class="fas fa-angle-down" aria-hidden="true"></i>
+            </span>
+          </button>
+        </div>
+        <div class="dropdown-menu" id="dropdown-menu" role="menu">
+          <div class="dropdown-content">
+            <a href="#" class="dropdown-item mark-all-read-button">
+            <span class="icon is-small">
+              <i class="fas fa-check" aria-hidden="true"></i>
+            </span> Mark All Read
+            </a>
+          </div>
+        </div>
+      </div>
     </h2>
   </div>
 
@@ -179,7 +223,6 @@
   </div>
 </div>
 
-
 <input type="hidden" id="last-id" value="<?= $entries[0]['_id'] ?? '' ?>">
 <input type="hidden" id="channel-uid" value="<?= $channel['uid'] ?>">
 <input type="hidden" id="destination-uid" value="<?= e($destination['uid'] ?? '') ?>">
@@ -293,6 +336,39 @@ $(function(){
         $("#new-post-content").addClass('is-danger');
       }
     });
+  });
+
+  // $(".mark-all-read-button a").click(function(){
+  //   $("#mark-all-read-modal").addClass("is-active");
+  // });
+
+  $("a.mark-all-read-button").click(function(e){
+    e.preventDefault();
+    var marked = {};
+    var entry_ids = [];
+    document.querySelectorAll(".entry").forEach(function(entry){
+      var entryNum = $(entry).data("entry");
+      if(marked[entryNum] == null && $(entry).data("is-read") == 0) {
+        marked[entryNum] = true;
+        entry_ids.push($(entry).data("entry-id"));
+      }
+    });
+    entry_ids.forEach(function(eid){
+      $(".entry[data-entry-id="+eid+"]").data("is-read", 1);
+      $(".entry[data-entry-id="+eid+"]").removeClass("unread").addClass("read");
+    });
+
+    $.post("/microsub/mark_all_as_read", {
+      channel: $("#channel-uid").val(),
+      entry: $("#last-id").val()
+    }, function(response){
+      update_channel_list(response.channels);
+      $("a.mark-all-read-button").parents(".dropdown").removeClass("is-active");
+    });
+    
+  });
+  $("#mark-all-read-modal a.close").click(function(){
+    $("#mark-all-read-modal").removeClass("is-active");
   });
 
   $(".content.html").each(function(i,content){
@@ -494,7 +570,6 @@ function mark_all_as_read() {
     channel: $("#channel-uid").val(),
     entry: $("#last-id").val()
   }, function(response){
-    console.log(response);
     update_channel_list(response.channels);
   });
 }

--- a/views/timeline.php
+++ b/views/timeline.php
@@ -475,6 +475,30 @@ function mark_read(entry_ids) {
   });
 }
 
+function mark_all_as_read() {
+  var marked = {};
+  var entry_ids = [];
+  document.querySelectorAll(".entry").forEach(function(entry){
+    var entryNum = $(entry).data("entry");
+    if(marked[entryNum] == null && $(entry).data("is-read") == 0) {
+      marked[entryNum] = true;
+      entry_ids.push($(entry).data("entry-id"));
+    }
+  });
+  entry_ids.forEach(function(eid){
+    $(".entry[data-entry-id="+eid+"]").data("is-read", 1);
+    $(".entry[data-entry-id="+eid+"]").removeClass("unread").addClass("read");
+  });
+
+  $.post("/microsub/mark_all_as_read", {
+    channel: $("#channel-uid").val(),
+    entry: $("#last-id").val()
+  }, function(response){
+    console.log(response);
+    update_channel_list(response.channels);
+  });
+}
+
 function mark_unread(entry_ids, callback=null) {
   if(typeof entry_ids != "object") {
     entry_ids = [entry_ids];


### PR DESCRIPTION
Implementing #12.

It works by taking the value of the hidden "last-id" input, feeding it to a POST request to the Microsub server as "last_read_entry", as per [the spec](https://indieweb.org/Microsub-spec#Timelines).

JavaScript will visually mark the entries as read and refresh the channel list, in line with the existing `mark_read` function.

UI is implemented for both desktop and mobile.