### PR TITLE
Update manifest to allow PWA support

### DIFF
--- a/public/icons/manifest.json
+++ b/public/icons/manifest.json
@@ -13,5 +13,11 @@
             "sizes": "512x512",
             "type": "image/png"
         }
-    ]
+    ],
+    "id": "/?source=pwa",
+    "start_url": "/?source=pwa",
+    "background_color": "#fff",
+    "display": "standalone",
+    "scope": "/",
+    "theme_color": "#fff"
 }


### PR DESCRIPTION
This PR adds the requisite attributes to the `manifest.json` file to allow adding the app to one's home screen as a PWA on iOS.